### PR TITLE
feat(bridge): Implement bi-directional logic and on-chain accounting 

### DIFF
--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -75,7 +75,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     //   runtime in substitute for the on-chain Wasm runtime unless all of `spec_name`,
     //   `spec_version`, and `authoring_version` are the same between Wasm and native.
     // This value is set to 105 - upgrade from previous 104
-    spec_version: 105,
+    spec_version: 106,
     impl_version: 1,
     apis: apis::RUNTIME_API_VERSIONS,
     transaction_version: 1,


### PR DESCRIPTION
### **feat(bridge): Implement bi-directional logic and on-chain accounting**

**Summary**

This PR introduces two major enhancements to the bridge pallet:

1.  **Enables True Bi-Directional Transfers**: The `release` function has been fundamentally refactored to correctly handle incoming transfers from Ethereum, making the bridge fully bi-directional.
2.  **Adds On-Chain Accounting**: New storage items have been added to provide a transparent, auditable record of the total volume of assets moving through the bridge.

---
**Changes**

* **`release()` Function Refactor:**
    * **Removed `LockedMessages` Lookup**: The `release` function no longer checks the `LockedMessages` storage map. This map is only relevant for the Substrate -> Ethereum direction.
    * The function now relies solely on verifying the federation's signatures for the incoming `message_id` and checking `ProcessedMessages` to prevent replays.

* **New Accounting Storage Items:**
    * Added `TotalLocked<T>` and `TotalReleased<T>` as `StorageValue` items to the pallet's storage.

* **Function Updates for Accounting:**
    * The `lock` extrinsic now increments the `TotalLocked` value.
    * The corrected `release` extrinsic now increments the `TotalReleased` value.

---
**Reasoning**

* **Fungible Bi-Directional Bridge**: The previous logic incorrectly checked for an original lock message on the return trip, making the bridge effectively one-way. By removing the `LockedMessages` lookup from the `release` function, we enable a true fungible bridge. Now, *any* user holding the wrapped token on Ethereum (whether they bridged it themselves or acquired it on a DEX) can securely bridge it back to the Substrate chain.
* **Transparency & Auditing**: The new `TotalLocked` and `TotalReleased` counters provide a simple and efficient way for anyone to query the total volume of assets that have flowed in and out of the bridge.
* **Solvency Check**: The net balance of the pallet's sovereign account can now be easily verified against `TotalLocked - TotalReleased`, providing an immediate on-chain metric for the bridge's solvency.

This is a critical update that fixes the bridge's core logic and adds valuable accounting functionality.